### PR TITLE
Typo correction (#574)

### DIFF
--- a/Duckling/Duration/TR/Rules.hs
+++ b/Duckling/Duration/TR/Rules.hs
@@ -43,7 +43,7 @@ ruleDurationHalfAnHour = Rule
 ruleDurationThreeQuartersOfAnHour :: Rule
 ruleDurationThreeQuartersOfAnHour = Rule
   { name = "three-quarters of an hour"
-  , pattern = [regex "(3/4\\s?sa(at)?|üçe \231eyrek sa(at)?)"]
+  , pattern = [regex "(3/4\\s?sa(at)?|üç \231eyrek sa(at)?)"]
   , prod = \_ -> Just . Token Duration $ duration TG.Minute 45
   }
 
@@ -89,7 +89,7 @@ ruleDurationAndHalfHour = Rule
   { name = "<integer> and an half hour"
   , pattern =
     [ Predicate isNatural
-    , regex "buçeuk sa(at)?"
+    , regex "buçuk sa(at)?"
     ]
   , prod = \tokens -> case tokens of
       (Token Numeral NumeralData{TNumeral.value = v}:_) ->


### PR DESCRIPTION
Summary:
This commit includes typo correction for `half` and `three` equivelant in Turkish

Pull Request resolved: https://github.com/facebook/duckling/pull/574

Reviewed By: girifb

Differential Revision: D26726718

Pulled By: chessai

fbshipit-source-id: 840c2d8e491057b6ccec81562ff64356789f587d